### PR TITLE
Setup Maven, Core Models, and Lexer (Tasks 1.1-1.3)

### DIFF
--- a/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/AbcTune.kt
+++ b/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/AbcTune.kt
@@ -1,0 +1,11 @@
+package io.github.ryangardner.abc.core.model
+
+/**
+ * Represents a fully parsed ABC tune.
+ * Immutable and thread-safe.
+ */
+data class AbcTune(
+    val header: TuneHeader,
+    val body: TuneBody,
+    val metadata: TuneMetadata
+)

--- a/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/Accidental.kt
+++ b/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/Accidental.kt
@@ -1,0 +1,5 @@
+package io.github.ryangardner.abc.core.model
+
+enum class Accidental {
+    SHARP, FLAT, NATURAL, DOUBLE_SHARP, DOUBLE_FLAT
+}

--- a/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/BarLineType.kt
+++ b/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/BarLineType.kt
@@ -1,0 +1,5 @@
+package io.github.ryangardner.abc.core.model
+
+enum class BarLineType {
+    SINGLE, DOUBLE, FINAL, REPEAT_START, REPEAT_END, REPEAT_BOTH
+}

--- a/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/Decoration.kt
+++ b/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/Decoration.kt
@@ -1,0 +1,5 @@
+package io.github.ryangardner.abc.core.model
+
+data class Decoration(
+    val value: String
+)

--- a/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/HeaderType.kt
+++ b/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/HeaderType.kt
@@ -1,0 +1,5 @@
+package io.github.ryangardner.abc.core.model
+
+enum class HeaderType {
+    REFERENCE, TITLE, KEY, METER, LENGTH, TEMPO, UNKNOWN
+}

--- a/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/KeySignature.kt
+++ b/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/KeySignature.kt
@@ -1,0 +1,14 @@
+package io.github.ryangardner.abc.core.model
+
+/**
+ * Represents a musical key signature.
+ *
+ * @property tonic The tonic note of the key.
+ * @property mode The mode of the key (e.g., Major, Minor).
+ * @property accidentals List of explicit accidentals.
+ */
+data class KeySignature @JvmOverloads constructor(
+    val tonic: String, // Placeholder, will be Pitch later
+    val mode: String = "Major", // Placeholder
+    val accidentals: List<String> = emptyList() // Placeholder
+)

--- a/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/MusicElement.kt
+++ b/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/MusicElement.kt
@@ -1,0 +1,35 @@
+package io.github.ryangardner.abc.core.model
+
+sealed class MusicElement {
+    abstract val duration: NoteDuration
+}
+
+data class NoteElement @JvmOverloads constructor(
+    val pitch: Pitch,
+    val length: NoteDuration,
+    val ties: TieType = TieType.NONE,
+    val decorations: List<Decoration> = emptyList(),
+    val accidental: Accidental? = null
+) : MusicElement() {
+    override val duration: NoteDuration get() = length
+}
+
+data class ChordElement @JvmOverloads constructor(
+    val notes: List<NoteElement>,
+    override val duration: NoteDuration,
+    val annotation: String? = null
+) : MusicElement()
+
+data class BarLineElement @JvmOverloads constructor(
+    val type: BarLineType,
+    val repeatCount: Int = 0
+) : MusicElement() {
+    override val duration: NoteDuration = NoteDuration(0, 1)
+}
+
+data class InlineFieldElement(
+    val fieldType: HeaderType,
+    val value: String
+) : MusicElement() {
+    override val duration: NoteDuration = NoteDuration(0, 1)
+}

--- a/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/MusicElement.kt
+++ b/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/MusicElement.kt
@@ -1,7 +1,7 @@
 package io.github.ryangardner.abc.core.model
 
-sealed class MusicElement {
-    abstract val duration: NoteDuration
+sealed interface MusicElement {
+    val duration: NoteDuration
 }
 
 data class NoteElement @JvmOverloads constructor(
@@ -10,7 +10,7 @@ data class NoteElement @JvmOverloads constructor(
     val ties: TieType = TieType.NONE,
     val decorations: List<Decoration> = emptyList(),
     val accidental: Accidental? = null
-) : MusicElement() {
+) : MusicElement {
     override val duration: NoteDuration get() = length
 }
 
@@ -18,18 +18,23 @@ data class ChordElement @JvmOverloads constructor(
     val notes: List<NoteElement>,
     override val duration: NoteDuration,
     val annotation: String? = null
-) : MusicElement()
+) : MusicElement
 
 data class BarLineElement @JvmOverloads constructor(
     val type: BarLineType,
     val repeatCount: Int = 0
-) : MusicElement() {
+) : MusicElement {
     override val duration: NoteDuration = NoteDuration(0, 1)
 }
 
 data class InlineFieldElement(
     val fieldType: HeaderType,
     val value: String
-) : MusicElement() {
+) : MusicElement {
     override val duration: NoteDuration = NoteDuration(0, 1)
 }
+
+data class RestElement @JvmOverloads constructor(
+    override val duration: NoteDuration,
+    val isInvisible: Boolean = false // x or X
+) : MusicElement

--- a/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/NoteDuration.kt
+++ b/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/NoteDuration.kt
@@ -1,0 +1,11 @@
+package io.github.ryangardner.abc.core.model
+
+/**
+ * Represents a note duration.
+ *
+ * @property value The duration value (e.g., 1/8).
+ */
+data class NoteDuration(
+    val numerator: Int,
+    val denominator: Int
+)

--- a/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/NoteStep.kt
+++ b/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/NoteStep.kt
@@ -1,0 +1,5 @@
+package io.github.ryangardner.abc.core.model
+
+enum class NoteStep {
+    C, D, E, F, G, A, B
+}

--- a/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/Pitch.kt
+++ b/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/Pitch.kt
@@ -1,0 +1,7 @@
+package io.github.ryangardner.abc.core.model
+
+data class Pitch @JvmOverloads constructor(
+    val step: NoteStep,
+    val octave: Int,
+    val accidental: Accidental? = null
+)

--- a/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/Tempo.kt
+++ b/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/Tempo.kt
@@ -1,0 +1,12 @@
+package io.github.ryangardner.abc.core.model
+
+/**
+ * Represents the tempo of the tune.
+ *
+ * @property bpm Beats per minute.
+ * @property beatUnit The note value that the beat refers to (optional).
+ */
+data class Tempo @JvmOverloads constructor(
+    val bpm: Int,
+    val beatUnit: NoteDuration? = null
+)

--- a/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/TieType.kt
+++ b/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/TieType.kt
@@ -1,0 +1,5 @@
+package io.github.ryangardner.abc.core.model
+
+enum class TieType {
+    NONE, START, END, BOTH
+}

--- a/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/TimeSignature.kt
+++ b/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/TimeSignature.kt
@@ -1,0 +1,14 @@
+package io.github.ryangardner.abc.core.model
+
+/**
+ * Represents a time signature (meter).
+ *
+ * @property numerator The number of beats per measure.
+ * @property denominator The note value that represents one beat.
+ * @property symbol Optional symbol representation (e.g., "C", "C|").
+ */
+data class TimeSignature @JvmOverloads constructor(
+    val numerator: Int,
+    val denominator: Int,
+    val symbol: String? = null
+)

--- a/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/TuneBody.kt
+++ b/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/TuneBody.kt
@@ -1,0 +1,5 @@
+package io.github.ryangardner.abc.core.model
+
+data class TuneBody(
+    val elements: List<MusicElement>
+)

--- a/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/TuneHeader.kt
+++ b/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/TuneHeader.kt
@@ -1,0 +1,20 @@
+package io.github.ryangardner.abc.core.model
+
+/**
+ * Represents the header of an ABC tune.
+ *
+ * @property reference Unique index of the tune (X:).
+ * @property title List of titles (T:).
+ * @property key Key signature (K:).
+ * @property meter Time signature (M:).
+ * @property length Default note length (L:).
+ * @property tempo Tempo (Q:).
+ */
+data class TuneHeader @JvmOverloads constructor(
+    val reference: Int,
+    val title: List<String>,
+    val key: KeySignature,
+    val meter: TimeSignature,
+    val length: NoteDuration,
+    val tempo: Tempo? = null
+)

--- a/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/TuneMetadata.kt
+++ b/abc-core/src/main/kotlin/io/github/ryangardner/abc/core/model/TuneMetadata.kt
@@ -1,0 +1,6 @@
+package io.github.ryangardner.abc.core.model
+
+data class TuneMetadata @JvmOverloads constructor(
+    val visualTranspose: Int? = null,
+    // val midi: MidiConfiguration? = null // Placeholder for now
+)

--- a/abc-parser/src/main/kotlin/io/github/ryangardner/abc/parser/AbcLexer.kt
+++ b/abc-parser/src/main/kotlin/io/github/ryangardner/abc/parser/AbcLexer.kt
@@ -186,19 +186,7 @@ class AbcLexer(private val input: String) : Iterator<Token> {
 
         // Rest 'z' or 'Z' or 'x' or 'X'
         if (char in "zZxX") {
-             // Treat rests as notes for now? Or separate token?
-             // TokenType doesn't have REST. I'll use NOTE for now or add REST?
-             // Architecture doc says "Represents a playable note or rest".
-             // I'll add REST to TokenType later if needed, for now NOTE is fine or UNKNOWN?
-             // Actually, 'z' is a rest. 'x' is invisible rest.
-             // I'll add REST to TokenType? The enum I created earlier has NOTE but no REST.
-             // I'll treat them as NOTE for now, since `NoteElement` likely handles pitch/rest distinction or `RestElement` exists?
-             // `MusicElement` had `NoteElement` and `ChordElement`. No `RestElement`.
-             // Maybe `NoteElement` with specific Pitch means rest?
-             // Or `MusicElement` sealed class needs `RestElement`.
-             // But for Lexer, a token is a token.
-             // I'll map z/Z/x/X to NOTE for now.
-             buffer.add(Token(TokenType.NOTE, consume().toString(), line, startCol))
+             buffer.add(Token(TokenType.REST, consume().toString(), line, startCol))
              return
         }
 

--- a/abc-parser/src/main/kotlin/io/github/ryangardner/abc/parser/AbcLexer.kt
+++ b/abc-parser/src/main/kotlin/io/github/ryangardner/abc/parser/AbcLexer.kt
@@ -1,0 +1,344 @@
+package io.github.ryangardner.abc.parser
+
+import java.util.ArrayDeque
+
+class AbcLexer(private val input: String) : Iterator<Token> {
+    private var position = 0
+    private var line = 1
+    private var column = 1
+    private var state = LexerState.HEADER
+    private val buffer = ArrayDeque<Token>()
+    private var pendingBodyTransition = false
+    private var eofEmitted = false
+
+    private enum class LexerState {
+        HEADER, BODY
+    }
+
+    override fun hasNext(): Boolean {
+        if (eofEmitted) return false
+        if (buffer.isNotEmpty()) return true
+        fillBuffer()
+        return buffer.isNotEmpty()
+    }
+
+    override fun next(): Token {
+        if (buffer.isEmpty()) {
+            fillBuffer()
+        }
+        if (buffer.isEmpty()) {
+            throw NoSuchElementException()
+        }
+        val token = buffer.removeFirst()
+        if (token.type == TokenType.EOF) {
+            eofEmitted = true
+        }
+        return token
+    }
+
+    private fun fillBuffer() {
+        if (position >= input.length) {
+            if (buffer.isEmpty() && !eofEmitted) {
+                buffer.add(Token(TokenType.EOF, "", line, column))
+            }
+            return
+        }
+
+        skipWhitespace()
+        if (position >= input.length) {
+             if (buffer.isEmpty() && !eofEmitted) {
+                 buffer.add(Token(TokenType.EOF, "", line, column))
+             }
+             return
+        }
+
+        when (state) {
+            LexerState.HEADER -> scanHeader()
+            LexerState.BODY -> scanBody()
+        }
+    }
+
+    private fun scanHeader() {
+        val char = peek()
+
+        // Comment
+        if (char == '%') {
+             scanCommentOrDirective()
+             return
+        }
+
+        // Newline
+        if (char == '\n' || char == '\r') {
+             scanNewline()
+             return
+        }
+
+        // Header Field: Letter followed by :
+        if (char.isLetter()) {
+            val nextChar = peek(1)
+            if (nextChar == ':') {
+                val startCol = column
+                val key = consume().toString() // Letter
+                consume() // :
+
+                buffer.add(Token(TokenType.HEADER_KEY, key, line, startCol))
+
+                // Read value until newline
+                val valueStartCol = column
+                val sb = StringBuilder()
+                while (position < input.length) {
+                    val c = peek()
+                    if (c == '\n' || c == '\r' || c == '%') break
+                    sb.append(consume())
+                }
+                buffer.add(Token(TokenType.HEADER_VALUE, sb.toString().trim(), line, valueStartCol))
+
+                if (key == "K") {
+                    pendingBodyTransition = true
+                }
+                return
+            }
+        }
+
+        // If not a header field, but we are in HEADER state, it might be a continuation or we should be in BODY?
+        // Standard says "The next line [after K:] is the start of the tune body."
+        // But if we encounter a line that is NOT a header field before K:?
+        // "A line beginning with a letter followed by a colon is a header field. Any other line is part of the tune body."
+        // So if it's NOT a header field, we should switch to BODY?
+        // But comments and empty lines are allowed in header.
+
+        // If it's not a comment, not a newline, and not a header field:
+        // Switch to BODY immediately?
+        // Let's assume yes.
+        state = LexerState.BODY
+        scanBody()
+    }
+
+    private fun scanBody() {
+        val char = peek()
+        val startCol = column
+
+        if (char == '%') {
+             scanCommentOrDirective()
+             return
+        }
+        if (char == '\n' || char == '\r') {
+             scanNewline()
+             return
+        }
+
+        // Bar Lines
+        if (char == '|') {
+             consume()
+             if (peek() == ']') {
+                 consume()
+                 buffer.add(Token(TokenType.BAR_LINE, "|]", line, startCol))
+             } else if (peek() == '|') {
+                 consume()
+                 buffer.add(Token(TokenType.BAR_LINE, "||", line, startCol))
+             } else if (peek() == ':') {
+                 consume()
+                 buffer.add(Token(TokenType.BAR_LINE, "|:", line, startCol))
+             } else {
+                 buffer.add(Token(TokenType.BAR_LINE, "|", line, startCol))
+             }
+             return
+        }
+
+        if (char == ':') {
+             if (peek(1) == '|') {
+                 consume()
+                 consume()
+                 buffer.add(Token(TokenType.BAR_LINE, ":|", line, startCol))
+                 return
+             }
+             // : inside body? Repeat start |: handled above.
+             // Maybe just consume as UNKNOWN?
+             consume()
+             buffer.add(Token(TokenType.UNKNOWN, ":", line, startCol))
+             return
+        }
+
+        // Chords or Inline Fields
+        if (char == '[') {
+            // Check for inline field [K:...]
+            if (peek(1).isLetter() && peek(2) == ':') {
+                scanInlineField()
+                return
+            }
+            // Chord start
+            consume()
+            buffer.add(Token(TokenType.CHORD_START, "[", line, startCol))
+            return
+        }
+
+        if (char == ']') {
+            consume()
+            buffer.add(Token(TokenType.CHORD_END, "]", line, startCol))
+            return
+        }
+
+        // Notes
+        if (char in "abcdefgABCDEFG") {
+            buffer.add(Token(TokenType.NOTE, consume().toString(), line, startCol))
+            return
+        }
+
+        // Rest 'z' or 'Z' or 'x' or 'X'
+        if (char in "zZxX") {
+             // Treat rests as notes for now? Or separate token?
+             // TokenType doesn't have REST. I'll use NOTE for now or add REST?
+             // Architecture doc says "Represents a playable note or rest".
+             // I'll add REST to TokenType later if needed, for now NOTE is fine or UNKNOWN?
+             // Actually, 'z' is a rest. 'x' is invisible rest.
+             // I'll add REST to TokenType? The enum I created earlier has NOTE but no REST.
+             // I'll treat them as NOTE for now, since `NoteElement` likely handles pitch/rest distinction or `RestElement` exists?
+             // `MusicElement` had `NoteElement` and `ChordElement`. No `RestElement`.
+             // Maybe `NoteElement` with specific Pitch means rest?
+             // Or `MusicElement` sealed class needs `RestElement`.
+             // But for Lexer, a token is a token.
+             // I'll map z/Z/x/X to NOTE for now.
+             buffer.add(Token(TokenType.NOTE, consume().toString(), line, startCol))
+             return
+        }
+
+        // Accidentals
+        if (char == '^' || char == '_' || char == '=') {
+            var acc = consume().toString()
+            if ((peek() == '^' && acc == "^") || (peek() == '_' && acc == "_")) {
+                acc += consume()
+            }
+            buffer.add(Token(TokenType.ACCIDENTAL, acc, line, startCol))
+            return
+        }
+
+        // Duration
+        if (char.isDigit() || char == '/') {
+            val sb = StringBuilder()
+            while (peek().isDigit() || peek() == '/') {
+                sb.append(consume())
+            }
+            buffer.add(Token(TokenType.DURATION, sb.toString(), line, startCol))
+            return
+        }
+
+        // Ties -
+        if (char == '-') {
+            buffer.add(Token(TokenType.TIE, consume().toString(), line, startCol))
+            return
+        }
+
+        // Slurs ( )
+        if (char == '(') {
+            buffer.add(Token(TokenType.SLUR_START, consume().toString(), line, startCol))
+            return
+        }
+        if (char == ')') {
+            buffer.add(Token(TokenType.SLUR_END, consume().toString(), line, startCol))
+            return
+        }
+
+        // Decorations !...! or . ~ etc
+        if (char == '!') {
+            consume()
+            val sb = StringBuilder()
+            while (position < input.length && peek() != '!' && peek() != '\n') {
+                sb.append(consume())
+            }
+            if (peek() == '!') consume()
+            buffer.add(Token(TokenType.DECORATION, sb.toString(), line, startCol))
+            return
+        }
+
+        if (char in ".~HLMSTuv") {
+             buffer.add(Token(TokenType.DECORATION, consume().toString(), line, startCol))
+             return
+        }
+
+        // Fallback
+        consume()
+        buffer.add(Token(TokenType.UNKNOWN, char.toString(), line, startCol))
+    }
+
+    private fun scanInlineField() {
+        val startCol = column
+        consume() // [
+        buffer.add(Token(TokenType.INLINE_FIELD_START, "[", line, startCol))
+
+        val key = consume().toString() // Letter
+        consume() // :
+        buffer.add(Token(TokenType.INLINE_FIELD_KEY, key, line, column - 2))
+
+        // Value until ]
+        val sb = StringBuilder()
+        while (position < input.length && peek() != ']') {
+            sb.append(consume())
+        }
+        buffer.add(Token(TokenType.INLINE_FIELD_VALUE, sb.toString(), line, column - sb.length))
+
+        if (peek() == ']') {
+             consume()
+             buffer.add(Token(TokenType.INLINE_FIELD_END, "]", line, column - 1))
+        }
+    }
+
+    private fun scanCommentOrDirective() {
+        val startCol = column
+        consume() // %
+        if (peek() == '%') {
+             consume() // %
+             val content = readUntilNewline()
+             buffer.add(Token(TokenType.DIRECTIVE, content, line, startCol))
+        } else {
+             val content = readUntilNewline()
+             buffer.add(Token(TokenType.COMMENT, content, line, startCol))
+        }
+    }
+
+    private fun scanNewline() {
+        val startCol = column
+        val c = consume() // \n or \r
+        if (c == '\r' && peek() == '\n') consume()
+
+        buffer.add(Token(TokenType.NEWLINE, "\n", line, startCol))
+        line++
+        column = 1
+
+        if (state == LexerState.HEADER && pendingBodyTransition) {
+            state = LexerState.BODY
+            pendingBodyTransition = false
+        }
+    }
+
+    private fun skipWhitespace() {
+        while (position < input.length) {
+            val c = peek()
+            if (c == ' ' || c == '\t') {
+                consume()
+            } else {
+                break
+            }
+        }
+    }
+
+    private fun readUntilNewline(): String {
+        val sb = StringBuilder()
+        while (position < input.length) {
+             val c = peek()
+             if (c == '\n' || c == '\r') break
+             sb.append(consume())
+        }
+        return sb.toString()
+    }
+
+    private fun peek(offset: Int = 0): Char {
+        if (position + offset >= input.length) return '\u0000'
+        return input[position + offset]
+    }
+
+    private fun consume(): Char {
+        val c = input[position++]
+        column++
+        return c
+    }
+}

--- a/abc-parser/src/main/kotlin/io/github/ryangardner/abc/parser/Token.kt
+++ b/abc-parser/src/main/kotlin/io/github/ryangardner/abc/parser/Token.kt
@@ -7,6 +7,7 @@ enum class TokenType {
 
     // Body
     NOTE,           // C, d, etc.
+    REST,           // z, Z, x, X
     ACCIDENTAL,     // ^, _, =
     DURATION,       // 2, /2, 3/4
     BAR_LINE,       // |, ||, |], :|, |:

--- a/abc-parser/src/main/kotlin/io/github/ryangardner/abc/parser/Token.kt
+++ b/abc-parser/src/main/kotlin/io/github/ryangardner/abc/parser/Token.kt
@@ -1,0 +1,41 @@
+package io.github.ryangardner.abc.parser
+
+enum class TokenType {
+    // Header
+    HEADER_KEY,     // X, T, M, etc.
+    HEADER_VALUE,   // The content of the header field
+
+    // Body
+    NOTE,           // C, d, etc.
+    ACCIDENTAL,     // ^, _, =
+    DURATION,       // 2, /2, 3/4
+    BAR_LINE,       // |, ||, |], :|, |:
+    CHORD_START,    // [
+    CHORD_END,      // ]
+    TIE,            // -
+    SLUR_START,     // (
+    SLUR_END,       // )
+    DECORATION,     // !...! or symbol like . ~
+
+    // Inline field
+    INLINE_FIELD_START, // [
+    INLINE_FIELD_KEY,   // K, M, etc. inside []
+    INLINE_FIELD_VALUE,
+    INLINE_FIELD_END,   // ]
+
+    // Common
+    WHITESPACE,
+    NEWLINE,
+    COMMENT,        // % ...
+    DIRECTIVE,      // %% ...
+    EOF,
+
+    UNKNOWN
+}
+
+data class Token(
+    val type: TokenType,
+    val text: String,
+    val line: Int,
+    val column: Int
+)

--- a/abc-parser/src/test/kotlin/io/github/ryangardner/abc/parser/AbcLexerTest.kt
+++ b/abc-parser/src/test/kotlin/io/github/ryangardner/abc/parser/AbcLexerTest.kt
@@ -36,7 +36,7 @@ class AbcLexerTest {
 
     @Test
     fun `test body transition and parsing`() {
-        val input = "K:C\nC D E |"
+        val input = "K:C\nC D z |"
         val lexer = AbcLexer(input)
         val tokens = lexer.asSequence().toList()
 
@@ -47,13 +47,13 @@ class AbcLexerTest {
         assertEquals("C", tokens[1].text)
         assertEquals(TokenType.NEWLINE, tokens[2].type) // Transitions to BODY here
 
-        // Body C D E |
+        // Body C D z |
         assertEquals(TokenType.NOTE, tokens[3].type)
         assertEquals("C", tokens[3].text)
         assertEquals(TokenType.NOTE, tokens[4].type) // Space skipped
         assertEquals("D", tokens[4].text)
-        assertEquals(TokenType.NOTE, tokens[5].type)
-        assertEquals("E", tokens[5].text)
+        assertEquals(TokenType.REST, tokens[5].type)
+        assertEquals("z", tokens[5].text)
         assertEquals(TokenType.BAR_LINE, tokens[6].type)
         assertEquals("|", tokens[6].text)
         assertEquals(TokenType.EOF, tokens[7].type)

--- a/abc-parser/src/test/kotlin/io/github/ryangardner/abc/parser/AbcLexerTest.kt
+++ b/abc-parser/src/test/kotlin/io/github/ryangardner/abc/parser/AbcLexerTest.kt
@@ -1,0 +1,83 @@
+package io.github.ryangardner.abc.parser
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class AbcLexerTest {
+    @Test
+    fun `test header parsing`() {
+        val input = """
+            X: 1
+            T: Test Tune
+            K: C
+        """.trimIndent()
+
+        val lexer = AbcLexer(input)
+        val tokens = lexer.asSequence().toList()
+
+        assertEquals(TokenType.HEADER_KEY, tokens[0].type)
+        assertEquals("X", tokens[0].text)
+        assertEquals(TokenType.HEADER_VALUE, tokens[1].type)
+        assertEquals("1", tokens[1].text)
+        assertEquals(TokenType.NEWLINE, tokens[2].type)
+
+        assertEquals(TokenType.HEADER_KEY, tokens[3].type)
+        assertEquals("T", tokens[3].text)
+        assertEquals(TokenType.HEADER_VALUE, tokens[4].type)
+        assertEquals("Test Tune", tokens[4].text)
+        assertEquals(TokenType.NEWLINE, tokens[5].type)
+
+        assertEquals(TokenType.HEADER_KEY, tokens[6].type)
+        assertEquals("K", tokens[6].text)
+        assertEquals(TokenType.HEADER_VALUE, tokens[7].type)
+        assertEquals("C", tokens[7].text)
+        assertEquals(TokenType.EOF, tokens[8].type)
+    }
+
+    @Test
+    fun `test body transition and parsing`() {
+        val input = "K:C\nC D E |"
+        val lexer = AbcLexer(input)
+        val tokens = lexer.asSequence().toList()
+
+        // Header K:C
+        assertEquals(TokenType.HEADER_KEY, tokens[0].type)
+        assertEquals("K", tokens[0].text)
+        assertEquals(TokenType.HEADER_VALUE, tokens[1].type)
+        assertEquals("C", tokens[1].text)
+        assertEquals(TokenType.NEWLINE, tokens[2].type) // Transitions to BODY here
+
+        // Body C D E |
+        assertEquals(TokenType.NOTE, tokens[3].type)
+        assertEquals("C", tokens[3].text)
+        assertEquals(TokenType.NOTE, tokens[4].type) // Space skipped
+        assertEquals("D", tokens[4].text)
+        assertEquals(TokenType.NOTE, tokens[5].type)
+        assertEquals("E", tokens[5].text)
+        assertEquals(TokenType.BAR_LINE, tokens[6].type)
+        assertEquals("|", tokens[6].text)
+        assertEquals(TokenType.EOF, tokens[7].type)
+    }
+
+    @Test
+    fun `test inline fields`() {
+        val input = "K:C\n[K:Dm] A B"
+        val lexer = AbcLexer(input)
+        val tokens = lexer.asSequence().toList()
+
+        // Skip header check, focus on body
+        val bodyTokens = tokens.drop(3) // Key, Value, Newline
+
+        assertEquals(TokenType.INLINE_FIELD_START, bodyTokens[0].type)
+        assertEquals("[", bodyTokens[0].text)
+        assertEquals(TokenType.INLINE_FIELD_KEY, bodyTokens[1].type)
+        assertEquals("K", bodyTokens[1].text)
+        assertEquals(TokenType.INLINE_FIELD_VALUE, bodyTokens[2].type)
+        assertEquals("Dm", bodyTokens[2].text) // Or "Dm" depending on logic
+        assertEquals(TokenType.INLINE_FIELD_END, bodyTokens[3].type)
+        assertEquals("]", bodyTokens[3].text)
+
+        assertEquals(TokenType.NOTE, bodyTokens[4].type) // A
+        assertEquals("A", bodyTokens[4].text)
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -54,11 +54,36 @@
                         <goals>
                             <goal>compile</goal>
                         </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>test-compile</id>
                         <goals>
                             <goal>test-compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.github.gantsign.maven</groupId>
+                <artifactId>ktlint-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>check</id>
+                        <goals>
+                            <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
This commit completes the initial setup tasks for LibABC-Kotlin:
1. Configured `ktlint-maven-plugin` in root `pom.xml`.
2. Implemented `AbcTune`, `TuneHeader`, and `MusicElement` sealed classes in `abc-core`.
3. Implemented `AbcLexer` and `Token` types in `abc-parser`.
4. Added `AbcLexerTest` and verified tokenization logic.
5. Configured `kotlin-maven-plugin` to recognize `src/main/kotlin` directories.

---
*PR created automatically by Jules for task [17033050423628065653](https://jules.google.com/task/17033050423628065653) started by @ryangardner*