### PR TITLE
chore: replace deprecated kotlin-stdlib-jdk8 with kotlin-stdlib

### DIFF
--- a/abc-core/pom.xml
+++ b/abc-core/pom.xml
@@ -15,7 +15,7 @@
     <dependencies>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <artifactId>kotlin-stdlib</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/abc-interop/pom.xml
+++ b/abc-interop/pom.xml
@@ -20,7 +20,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <artifactId>kotlin-stdlib</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/abc-parser/pom.xml
+++ b/abc-parser/pom.xml
@@ -20,7 +20,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <artifactId>kotlin-stdlib</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/abc-theory/pom.xml
+++ b/abc-theory/pom.xml
@@ -20,7 +20,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <artifactId>kotlin-stdlib</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -279,7 +279,7 @@ XML
         \<dependencies\>  
             \<dependency\>  
                 \<groupId\>org.jetbrains.kotlin\</groupId\>  
-                \<artifactId\>kotlin-stdlib-jdk8\</artifactId\>  
+                \<artifactId\>kotlin-stdlib\</artifactId\>
                 \<version\>${kotlin.version}\</version\>  
             \</dependency\>  
             \<dependency\>  

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <dependencies>
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib-jdk8</artifactId>
+                <artifactId>kotlin-stdlib</artifactId>
                 <version>${kotlin.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Updated all pom.xml files and documentation to use the unified kotlin-stdlib artifact instead of the deprecated kotlin-stdlib-jdk8, aligning with Kotlin 1.8+ standards.