### PR TITLE
🔒 fix: Zip Slip vulnerability in DatasetDownloader

### DIFF
--- a/abc-test/src/test/kotlin/io/github/ryangardner/abc/test/DatasetDownloaderSecurityTest.kt
+++ b/abc-test/src/test/kotlin/io/github/ryangardner/abc/test/DatasetDownloaderSecurityTest.kt
@@ -1,0 +1,40 @@
+package io.github.ryangardner.abc.test
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.IOException
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+import kotlin.test.assertFailsWith
+
+class DatasetDownloaderSecurityTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    @Test
+    fun `test zip slip vulnerability`() {
+        val outputDir = File(tempDir, "output")
+        outputDir.mkdirs()
+
+        val bos = ByteArrayOutputStream()
+        ZipOutputStream(bos).use { zos ->
+            val entry = ZipEntry("../evil.txt")
+            zos.putNextEntry(entry)
+            zos.write("malicious content".toByteArray())
+            zos.closeEntry()
+        }
+
+        val zis = ZipInputStream(ByteArrayInputStream(bos.toByteArray()))
+
+        // Before the fix, this should NOT throw an IOException (it should create the file outside outputDir)
+        // After the fix, this SHOULD throw an IOException
+        assertFailsWith<IOException> {
+            DatasetDownloader.extract(zis, outputDir)
+        }
+    }
+}


### PR DESCRIPTION
This commit addresses a critical directory traversal vulnerability (Zip Slip) in the `DatasetDownloader` utility. The fix ensures that extracted files cannot escape the intended output directory by canonicalizing the destination path and verifying it starts with the target directory.

- Refactored extraction logic into a testable internal function.
- Implemented path validation using canonical paths and File.separator.
- Added a security test case in `DatasetDownloaderSecurityTest`.