### PR TITLE
perf: move Regex recreation in InterpretationUtils to static constants

### DIFF
--- a/abc-theory/src/main/kotlin/io/github/ryangardner/abc/theory/PitchInterpreter.kt
+++ b/abc-theory/src/main/kotlin/io/github/ryangardner/abc/theory/PitchInterpreter.kt
@@ -110,6 +110,7 @@ internal class InterpretationSession(val tune: AbcTune) {
 
 public object PitchInterpreter {
     private val logger: Logger = LoggerFactory.getLogger(PitchInterpreter::class.java)
+    private val WHITESPACE_REGEX = "\\s+".toRegex()
 
     /**
      * Converts an AbcTune to a Timeline, providing a high-level view of musical events.
@@ -145,7 +146,7 @@ public object PitchInterpreter {
                     }
                     "%%" -> {
                         if (value.startsWith("MIDI transpose", ignoreCase = true)) {
-                            val transpose = value.split("\\s+".toRegex()).last().toIntOrNull() ?: 0
+                            val transpose = value.split(WHITESPACE_REGEX).last().toIntOrNull() ?: 0
                             session.globalMidiTranspose = transpose
                             session.voiceStates.values.forEach { it.midiTranspose = transpose }
                         }
@@ -193,7 +194,7 @@ public object PitchInterpreter {
 
         fun handleDirective(session: InterpretationSession, element: DirectiveElement) {
             if (element.content.startsWith("MIDI transpose", ignoreCase = true)) {
-                session.currentVoiceState().midiTranspose = element.content.split("\\s+".toRegex()).last().toIntOrNull() ?: 0
+                session.currentVoiceState().midiTranspose = element.content.split(WHITESPACE_REGEX).last().toIntOrNull() ?: 0
             }
         }
     }

--- a/abc-theory/src/main/kotlin/io/github/ryangardner/abc/theory/util/InterpretationUtils.kt
+++ b/abc-theory/src/main/kotlin/io/github/ryangardner/abc/theory/util/InterpretationUtils.kt
@@ -3,6 +3,9 @@ package io.github.ryangardner.abc.theory.util
 import io.github.ryangardner.abc.core.model.*
 
 internal object InterpretationUtils {
+    private val TRANSPOSE_REGEX = "transpose=([-]?\\d+)".toRegex()
+    private val OCTAVE_REGEX = "octave=([-]?\\d+)".toRegex()
+
     fun parseCombinedTransposition(text: String): Int? {
         val lower = text.lowercase()
         var totalShift = 0
@@ -24,15 +27,13 @@ internal object InterpretationUtils {
         }
 
         // 2. Check for transpose=N
-        val transposeRegex = "transpose=([-]?\\d+)".toRegex()
-        transposeRegex.find(text)?.let {
+        TRANSPOSE_REGEX.find(text)?.let {
             totalShift += it.groupValues[1].toIntOrNull() ?: 0
             foundAny = true
         }
 
         // 3. Check for octave=N
-        val octaveRegex = "octave=([-]?\\d+)".toRegex()
-        octaveRegex.find(text)?.let {
+        OCTAVE_REGEX.find(text)?.let {
             totalShift += (it.groupValues[1].toIntOrNull() ?: 0) * 12
             foundAny = true
         }

--- a/abc-theory/src/main/kotlin/io/github/ryangardner/abc/theory/util/KeyParserUtil.kt
+++ b/abc-theory/src/main/kotlin/io/github/ryangardner/abc/theory/util/KeyParserUtil.kt
@@ -18,12 +18,14 @@ public object KeyParserUtil {
         "treble", "bass", "alto", "tenor", "perc", "none", "mezzosoprano", "soprano", "baritone", "subbass"
     )
 
+    private val WHITESPACE_REGEX = "\\s+".toRegex()
+
     public fun parse(keyText: String): KeySignature {
         val trimmed = keyText.substringBefore("%").trim()
         if (trimmed.isEmpty()) {
             return KeySignature(KeyRoot(NoteStep.C, Accidental.NATURAL), KeyMode.IONIAN)
         }
-        val parts = trimmed.split("\\s+".toRegex())
+        val parts = trimmed.split(WHITESPACE_REGEX)
         var firstWord = parts[0]
         
         // If the first word is a known clef name, the key is implicitly C Major


### PR DESCRIPTION
Moved the creation of Regex objects for transposition and octave parsing in InterpretationUtils.kt out of the parseCombinedTransposition method and into private constants.

Also optimized similar regex recreation in KeyParserUtil.kt and PitchInterpreter.kt where whitespace splitting regexes were being recreated on every call.

This avoids unnecessary recompilation and allocation of Regex objects, making these frequently called utility methods more efficient.